### PR TITLE
Return local positions

### DIFF
--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -10,6 +10,7 @@ use crate::{
     compressed_suffix_array::CompressedSuffixArray,
     kmer_lookup_table::KmerLookupTable,
     search::{SearchPtr, SearchRange},
+    sequence_index::{LocalizedSequencePosition, SequenceIndex},
 };
 
 pub const FM_VERSION_NUMBER: u64 = 1;
@@ -28,6 +29,8 @@ pub struct FmIndex {
     bwt_len: u64,
     /// version number of this struct implementation
     version_number: u64,
+    /// sequence index storing the headers, start positions, and lengths of the sequences
+    sequence_index: SequenceIndex,
 }
 
 const DEFAULT_SUFFIX_ARRAY_FILE_NAME: &str = "sa.sufr";
@@ -40,15 +43,15 @@ pub struct FmBuildArgs {
     suffix_array_output_src: Option<String>,
     ///How much to downsample the suffix array. downsampling increases locate() time but decreases memory usage
     suffix_array_compression_ratio: Option<u8>,
-    ///Kmer length in the lookup table. Skips the first k search steps at the cost of exponential memory. 
+    ///Kmer length in the lookup table. Skips the first k search steps at the cost of exponential memory.
     /// If None, uses sensible defaults.
     lookup_table_kmer_len: Option<u8>,
     ///alphabet of the input text, and therefore the FM-index.
     alphabet: SymbolAlphabet,
-    ///Maximum length to allow for searching, or None for unlimited. Setting this slightly speeds up build times, 
+    ///Maximum length to allow for searching, or None for unlimited. Setting this slightly speeds up build times,
     /// but may fail if searching for longer queries than specified/
     max_query_len: Option<usize>,
-    ///If true, will delete the intermediate suffix array file when done. 
+    ///If true, will delete the intermediate suffix array file when done.
     /// This file is unnecessary for proper functionality of the FM-index.
     remove_intermediate_suffix_array_file: bool,
 }
@@ -69,6 +72,8 @@ impl FmIndex {
             b'X'
         };
         let seq_data = read_sequence_file(&args.input_file_src, sequence_delimiter)?;
+        let sequence_index = SequenceIndex::from_seq_file_data(&seq_data);
+
         let sufr_builder_args = SufrBuilderArgs {
             text: seq_data.seq,
             max_query_len: args.max_query_len,
@@ -161,6 +166,7 @@ impl FmIndex {
             kmer_lookup_table: KmerLookupTable::empty(lookup_table_kmer_len, args.alphabet),
             bwt_len,
             version_number: FM_VERSION_NUMBER,
+            sequence_index,
         };
 
         //now that the fm index has been generated, we can populate the kmer lookup table
@@ -183,6 +189,7 @@ impl FmIndex {
         kmer_lookup_table: KmerLookupTable,
         bwt_len: u64,
         version_number: u64,
+        sequence_index: SequenceIndex,
     ) -> FmIndex {
         FmIndex {
             bwt,
@@ -191,6 +198,7 @@ impl FmIndex {
             kmer_lookup_table,
             bwt_len,
             version_number,
+            sequence_index,
         }
     }
 
@@ -236,6 +244,9 @@ impl FmIndex {
     pub fn kmer_lookup_table(&self) -> &KmerLookupTable {
         return &self.kmer_lookup_table;
     }
+    pub fn sequence_index(&self) -> &SequenceIndex {
+        return &self.sequence_index;
+    }
 
     /// Finds the search range for the given query. This is the heart of the count() and locate() functions.
     pub fn get_search_range_for_string(&self, query: &String) -> SearchRange {
@@ -279,7 +290,7 @@ impl FmIndex {
     }
 
     // Finds the locations for each query in the query list. This function uses rayon's into_par_iter() for parallelism.
-    pub fn parallel_locate(&self, queries: &Vec<String>) -> Vec<Vec<u64>> {
+    pub fn parallel_locate(&self, queries: &Vec<String>) -> Vec<Vec<LocalizedSequencePosition>> {
         queries
             .into_par_iter()
             .map(|query| self.locate_string(&query))
@@ -292,8 +303,8 @@ impl FmIndex {
     }
 
     /// Finds the locations in the original text of all isntances of the given query.
-    pub fn locate_string(&self, query: &String) -> Vec<u64> {
-        let mut string_locations: Vec<u64> = Vec::new();
+    pub fn locate_string(&self, query: &String) -> Vec<LocalizedSequencePosition> {
+        let mut string_locations: Vec<LocalizedSequencePosition> = Vec::new();
         let search_range = self.get_search_range_for_string(query);
 
         // backstep each location until we find a sampled position
@@ -312,7 +323,11 @@ impl FmIndex {
             let sequence_position = self.sampled_suffix_array.reconstruct_value(backstep_position as usize).expect("unable to read from the given suffix array position, this is likely an implementation bug or corrupted data.");
             let location = (sequence_position + num_backsteps_taken) % self.bwt_len;
 
-            string_locations.push(location);
+            let localized_position: LocalizedSequencePosition = self
+                .sequence_index
+                .get_seq_location(location as usize)
+                .expect("unable to find sequence location for given position");
+            string_locations.push(localized_position);
         }
 
         string_locations
@@ -408,7 +423,7 @@ mod tests {
             );
 
             for i in 0..locate_result.len() {
-                assert_eq!(locate_result[i] as usize , reference_positions[i], "position did not match in lists between locate results and reference positions");
+                assert_eq!(locate_result[i].local_position() as usize , reference_positions[i], "position did not match in lists between locate results and reference positions");
             }
         }
     }
@@ -490,9 +505,9 @@ mod tests {
 
     #[test]
     fn test_fastq_input() -> anyhow::Result<()> {
-        const FASTQ_SRC:&str = "test.fastq";
-        const SUFFIX_ARRAY_SRC:&str = "test_fastq.sa";
-        const FM_INDEX_SRC:&str = "fastq.awry";
+        const FASTQ_SRC: &str = "test.fastq";
+        const SUFFIX_ARRAY_SRC: &str = "test_fastq.sa";
+        const FM_INDEX_SRC: &str = "fastq.awry";
 
         let num_sequences = 30;
         let mut rng = thread_rng();
@@ -522,12 +537,15 @@ mod tests {
         Ok(())
     }
 
-    fn can_find_all_kmers_in_fasq_index(fm_index:&FmIndex,  sequences:&Vec<String>){
-        for sequence in sequences{
-            for kmer_start_idx in 0..sequence.len(){
+    fn can_find_all_kmers_in_fasq_index(fm_index: &FmIndex, sequences: &Vec<String>) {
+        for sequence in sequences {
+            for kmer_start_idx in 0..sequence.len() {
                 let query = sequence[kmer_start_idx..sequence.len()].to_owned();
                 let kmer_count = fm_index.count_string(&query);
-                assert_ne!(kmer_count, 0, "Kmer count returned zero for kmer in the database sequence list");
+                assert_ne!(
+                    kmer_count, 0,
+                    "Kmer count returned zero for kmer in the database sequence list"
+                );
             }
         }
     }
@@ -657,14 +675,26 @@ mod tests {
             let quality_string = (0..seq_length)
                 .map(|_| quality_char_set.choose(&mut rng).unwrap())
                 .collect::<String>();
-            
+
             let header_string = format!("@dummy-0:{}+\n", seq_length);
-            fastq_file.write_all(header_string.as_bytes()).expect("could not write to fastq file");
-            fastq_file.write_all(sequence.as_bytes()).expect("could not write to fastq file");
-            fastq_file.write_all("\n".as_bytes()).expect("could not write to fastq file");
-            fastq_file.write_all("+\n".as_bytes()).expect("could not write to fastq file");
-            fastq_file.write_all(quality_string.as_bytes()).expect("could not write to fastq file");
-            fastq_file.write_all("\n".as_bytes()).expect("could not write to fastq file");
+            fastq_file
+                .write_all(header_string.as_bytes())
+                .expect("could not write to fastq file");
+            fastq_file
+                .write_all(sequence.as_bytes())
+                .expect("could not write to fastq file");
+            fastq_file
+                .write_all("\n".as_bytes())
+                .expect("could not write to fastq file");
+            fastq_file
+                .write_all("+\n".as_bytes())
+                .expect("could not write to fastq file");
+            fastq_file
+                .write_all(quality_string.as_bytes())
+                .expect("could not write to fastq file");
+            fastq_file
+                .write_all("\n".as_bytes())
+                .expect("could not write to fastq file");
 
             sequences.push(sequence);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod fm_index_file;
 pub mod kmer_lookup_table;
 pub mod search;
 pub mod simd_instructions;
+pub mod sequence_index;
 
 #[cfg(test)]
 mod tests {

--- a/src/sequence_index.rs
+++ b/src/sequence_index.rs
@@ -1,0 +1,132 @@
+use anyhow::Ok;
+use libsufr::SequenceFileData;
+
+struct SequenceMetadata {
+    start_position: usize,
+    header: String,
+}
+
+pub struct SequenceIndex {
+    sequences: Vec<SequenceMetadata>,
+}
+
+#[derive(Ord, PartialOrd, Eq, PartialEq)]
+pub struct LocalizedSequencePosition {
+    sequence_idx: usize,
+    local_position: usize,
+}
+
+impl LocalizedSequencePosition {
+    pub fn new(sequence_idx: usize, local_position: usize) -> Self {
+        LocalizedSequencePosition {
+            sequence_idx,
+            local_position,
+        }
+    }
+    pub fn local_position(&self) -> usize {
+        self.local_position
+    }
+    pub fn sequence_idx(&self) -> usize {
+        self.sequence_idx
+    }
+}
+
+impl SequenceIndex {
+    pub fn new() -> Self {
+        SequenceIndex {
+            sequences: Vec::new(),
+        }
+    }
+    pub fn from_seq_file_data(seq_file_data: &SequenceFileData) -> Self {
+        let mut sequence_index: SequenceIndex = SequenceIndex::new();
+        for seq_idx in 0..seq_file_data.headers.len() {
+            sequence_index.add_sequence(
+                &seq_file_data.headers[seq_idx],
+                seq_file_data.start_positions[seq_idx],
+            );
+        }
+
+        return sequence_index;
+    }
+
+    pub fn add_sequence(&mut self, header: &str, start_position: usize) {
+        self.sequences.push(SequenceMetadata {
+            start_position,
+            header: header.to_string(),
+        })
+    }
+    pub fn get_seq_location(&self, global_position: usize) -> Option<LocalizedSequencePosition> {
+        return self.find_sequence_binary_search(global_position, 0, self.sequences.len() - 1);
+    }
+    fn find_sequence_binary_search(
+        &self,
+        global_position: usize,
+        range_low: usize,
+        range_high: usize,
+    ) -> Option<LocalizedSequencePosition> {
+        if range_low == range_high {
+            return Some(LocalizedSequencePosition::new(
+                range_low,
+                global_position - self.sequences[range_low].start_position,
+            ));
+        }
+        let midpoint = (range_low + range_high) / 2;
+        if self.sequences[midpoint].start_position > global_position {
+            self.find_sequence_binary_search(global_position, range_low, midpoint)
+        } else if self.sequences[midpoint].start_position < global_position {
+            self.find_sequence_binary_search(global_position, midpoint, range_high)
+        } else {
+            Some(LocalizedSequencePosition {
+                sequence_idx: midpoint,
+                local_position: global_position - self.sequences[midpoint].start_position,
+            })
+        }
+    }
+
+    pub fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), anyhow::Error> {
+        writer.write_all(&(self.sequences.len() as u64).to_le_bytes())?;
+        for sequence in self.sequences.iter() {
+            writer.write_all(&(sequence.start_position as u64).to_le_bytes())?;
+            writer.write_all(&(sequence.header.len() as u64).to_le_bytes())?;
+            writer.write_all(sequence.header.as_bytes())?;
+        }
+        return Ok(());
+    }
+
+    pub fn from_file<R: std::io::Read>(reader: &mut R) -> Result<Self, anyhow::Error> {
+        let mut sequence_index: SequenceIndex = SequenceIndex::new();
+        //read the number of sequences as a usize
+        let mut u64_buffer: [u8; 8] = [0; 8];
+        reader.read_exact(&mut u64_buffer)?;
+        let num_sequences = u64::from_le_bytes(u64_buffer);
+
+        for _ in 0..num_sequences {
+            //read the start position as a usize
+            reader.read_exact(&mut u64_buffer)?;
+            let start_position = u64::from_le_bytes(u64_buffer) as usize;
+            //read the length of the header as a usize
+            reader.read_exact(&mut u64_buffer)?;
+            let header_len = u64::from_le_bytes(u64_buffer);
+            //read the header. since header_len is non a constant, we need to read the header in chunks
+            //and construct a string of length header_len
+            let mut header_string = String::new();
+            let mut remaining_header_len = header_len;
+            while remaining_header_len > 0 {
+                let mut header_buffer: [u8; 1024] = [0; 1024];
+                if remaining_header_len > 1024 {
+                    reader.read_exact(&mut header_buffer)?;
+                    remaining_header_len -= 1024;
+                } else {
+                    reader.read_exact(&mut header_buffer[0..remaining_header_len as usize])?;
+                    remaining_header_len = 0;
+                }
+                //append the buffer to header_string
+                header_string.push_str(std::str::from_utf8(&header_buffer).unwrap());
+            }
+
+            sequence_index.add_sequence(&header_string, start_position);
+        }
+
+        return Ok(sequence_index);
+    }
+}


### PR DESCRIPTION
change the locate() function to return the index and local position of the matches, rather than a concatenated global position.