### PR TITLE
update SA compression ratio to u64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ aligned = "0.4.2"
 rand = "0.8.5"
 serde = { version = "1.0.215", features = ["derive"] }
 mem_dbg = "0.2.4"
-libsufr = "0.6.1"
+libsufr = "0.6.2"
 
 [lib]
 crate-type = ["lib"]

--- a/src/compressed_suffix_array.rs
+++ b/src/compressed_suffix_array.rs
@@ -12,7 +12,7 @@ pub(crate) struct CompressedSuffixArray {
     ///Actual Suffix Array values, compressed to remove leading zeros
     data: Vec<u64>,
     /// By what factor is the suffix array downsampled. a ratio of n only stores values whose indices are divisible by n.
-    suffix_array_compression_ratio: usize,
+    suffix_array_compression_ratio: u64,
     /// how many bits are required to store each value, i.e., an unsampled SA of length n will require log2_ceil(n) bits per element.
     bits_per_element: usize,
 }
@@ -20,7 +20,7 @@ pub(crate) struct CompressedSuffixArray {
 impl CompressedSuffixArray {
     /// Allocates space for a new Compressed Suffix Array, given the total uncompressed length and a compression ratio.
     ///
-    pub(crate) fn new(uncompressed_length: usize, suffix_array_compression_ratio: usize) -> Self {
+    pub(crate) fn new(uncompressed_length: usize, suffix_array_compression_ratio: u64) -> Self {
         debug_assert_ne!(
             uncompressed_length, 0,
             "length of compressed suffix array should not be zero"
@@ -41,7 +41,7 @@ impl CompressedSuffixArray {
     pub(crate) fn data(&self) -> &Vec<u64> {
         &self.data
     }
-    pub(crate) fn compression_ratio(&self) -> usize {
+    pub(crate) fn compression_ratio(&self) -> u64 {
         self.suffix_array_compression_ratio
     }
 
@@ -107,15 +107,15 @@ impl CompressedSuffixArray {
 
     /// Returns true if the given position is sampled in the compressed suffix array.
     pub fn position_is_sampled(&self, unsampled_position: usize) -> bool {
-        return unsampled_position % self.suffix_array_compression_ratio == 0;
+        return unsampled_position % self.suffix_array_compression_ratio as usize == 0;
     }
 
     pub(crate) fn compressed_word_len(
         bwt_len: usize,
-        suffix_array_compression_ratio: usize,
+        suffix_array_compression_ratio: u64,
     ) -> usize {
         let bits_per_element = Self::bits_per_element(bwt_len);
-        let num_compressed_elements = bwt_len.div_ceil(suffix_array_compression_ratio);
+        let num_compressed_elements = bwt_len.div_ceil(suffix_array_compression_ratio as usize);
         let suffix_array_num_words =
             (num_compressed_elements as u128 * bits_per_element as u128).div_ceil(64) as usize;
 
@@ -139,8 +139,8 @@ mod tests {
         let sa_len = 123451usize;
         let sa_values: Vec<u64> = (0..sa_len as u64).collect();
 
-        for compression_ratio in 1usize..16 {
-            let compressed_length = sa_len / compression_ratio;
+        for compression_ratio in 1u64..16 {
+            let compressed_length = sa_len / compression_ratio as usize;
             let mut csa = CompressedSuffixArray::new(sa_len as usize, compression_ratio);
 
             assert_eq!(

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -81,7 +81,7 @@ pub struct FmBuildArgs {
     ///file source to output the intermediate suffix array file.
     pub suffix_array_output_src: Option<PathBuf>,
     ///How much to downsample the suffix array. downsampling increases locate() time but decreases memory usage
-    pub suffix_array_compression_ratio: Option<u8>,
+    pub suffix_array_compression_ratio: Option<u64>,
     ///Kmer length in the lookup table. Skips the first k search steps at the cost of exponential memory.
     /// If None, uses sensible defaults.
     pub lookup_table_kmer_len: Option<u8>,
@@ -100,7 +100,7 @@ impl FmBuildArgs {
     pub fn new(
         input_file_src: PathBuf,
         suffix_array_output_src: Option<PathBuf>,
-        suffix_array_compression_ratio: Option<u8>,
+        suffix_array_compression_ratio: Option<u64>,
         lookup_table_kmer_len: Option<u8>,
         alphabet: SymbolAlphabet,
         max_query_len: Option<usize>,
@@ -119,7 +119,7 @@ impl FmBuildArgs {
 }
 
 impl FmIndex {
-    const DEFAULT_SUFFIX_ARRAY_COMPRESSION_RATIO: u8 = 8;
+    const DEFAULT_SUFFIX_ARRAY_COMPRESSION_RATIO: u64 = 8;
 
     /// Construct a new FM-index using the supplied build args.
     ///
@@ -184,7 +184,7 @@ impl FmIndex {
             .suffix_array_compression_ratio
             .unwrap_or(Self::DEFAULT_SUFFIX_ARRAY_COMPRESSION_RATIO);
         let mut compressed_suffix_array =
-            CompressedSuffixArray::new(bwt_len as usize, sa_compression_ratio as usize);
+            CompressedSuffixArray::new(bwt_len as usize, sa_compression_ratio);
 
         //find the number of blocks needed (integer ceiling funciton)
         let num_bwt_blocks = bwt_len.div_ceil(Bwt::NUM_SYMBOLS_PER_BLOCK);
@@ -316,7 +316,7 @@ impl FmIndex {
     /// let fm_index = FmIndex::load(&Path::new("test.awry")).expect("unable to load fm index from file");
     /// let suffix_array_compression_ratio = fm_index.suffix_array_compression_ratio();
     /// ```
-    pub fn suffix_array_compression_ratio(&self) -> usize {
+    pub fn suffix_array_compression_ratio(&self) -> u64 {
         self.sampled_suffix_array.compression_ratio()
     }
 

--- a/src/fm_index_file.rs
+++ b/src/fm_index_file.rs
@@ -172,7 +172,7 @@ impl FmIndex {
 
                 //Matches version 1
                 return [self.version_number(), 
-                self.suffix_array_compression_ratio() as u64, 
+                self.suffix_array_compression_ratio(), 
                 self.bwt_len(), 
                 alphabet_idx];
 
@@ -187,7 +187,7 @@ impl FmIndex {
                 let mut u64_buffer: [u8; 8] = [0; 8];
                 //currently only version 1 is supported.
                 fm_index_file.read_exact(&mut u64_buffer)?;
-                let suffix_array_compression_ratio = usize::from_le_bytes(u64_buffer);
+                let suffix_array_compression_ratio = u64::from_le_bytes(u64_buffer);
 
                 fm_index_file.read_exact(&mut u64_buffer)?;
                 let bwt_len =  u64::from_le_bytes(u64_buffer);


### PR DESCRIPTION
This now allows us to compress the suffix array more densly, which is great when you only need to perform count() operations